### PR TITLE
Feat: Add dark mode and improve UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,11 +13,24 @@
   --cor-cabecalho: #343a40;
   --sombra-suave: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
 }
+[data-theme="dark"] {
+  --cor-fundo: #121212;
+  --cor-superficie: #1e1e1e;
+  --cor-borda: #333;
+  --cor-texto-principal: #e0e0e0;
+  --cor-texto-secundario: #a0a0a0;
+  --cor-primaria: #bb86fc;
+  --cor-primaria-hover: #a050f0;
+  --cor-sucesso: #03dac6;
+  --cor-perigo: #cf6679;
+  --cor-cabecalho: #1f1f1f;
+  --sombra-suave: 0 4px 8px rgba(0,0,0,0.25);
+}
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(--cor-texto-principal);line-height:1.6}
+body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(--cor-texto-principal);line-height:1.6; transition: background-color 0.3s, color 0.3s;}
 .container{max-width:1200px;margin:0 auto;padding:20px}
-.header{background:linear-gradient(135deg,#343a40,#495057);color:#fff;padding:30px 20px;text-align:center;margin-bottom:30px;border-radius:12px;position:relative;box-shadow:var(--sombra-suave)}
+.header{background:var(--cor-cabecalho);color:#fff;padding:30px 20px;text-align:center;margin-bottom:30px;border-radius:12px;position:relative;box-shadow:var(--sombra-suave); border: 1px solid var(--cor-borda);}
 .header h1{font-size:2.2rem;margin-bottom:10px;font-weight:700}
 .header p{font-size:1.1rem;opacity:.9}
 .header-actions {
@@ -29,12 +42,34 @@ body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(
     align-items: center;
     justify-content: space-between;
 }
-.screen{display:none;background:var(--cor-superficie);padding:30px;border-radius:12px;box-shadow:var(--sombra-suave)}
+.header-actions .left-actions {
+    display: flex;
+    gap: 8px;
+}
+.theme-toggle-btn {
+    background: none;
+    border: 1px solid var(--cor-borda);
+    color: var(--cor-texto-principal);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s;
+}
+.theme-toggle-btn:hover {
+    background-color: rgba(255,255,255,0.1);
+    border-color: var(--cor-primaria);
+}
+.screen{display:none;background:var(--cor-superficie);padding:30px;border-radius:12px;box-shadow:var(--sombra-suave); border: 1px solid var(--cor-borda);}
 .screen.active{display:block}
 .exam-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px;margin-top:20px}
 .exam-card{border:1px solid var(--cor-borda);border-radius:12px;padding:25px;cursor:pointer;transition:all .2s ease-in-out;background-color:var(--cor-superficie);position:relative}
 .exam-card:hover{border-color:var(--cor-primaria);transform:translateY(-4px);box-shadow:0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -4px rgba(0,0,0,.1)}
-.exam-card.selected{border-color:var(--cor-sucesso);background-color:#f0fff4;box-shadow:0 0 0 2px rgba(40,167,69,.25)}
+.exam-card.selected{border-color:var(--cor-sucesso);background-color:rgba(3, 218, 198, 0.1);box-shadow:0 0 0 2px var(--cor-sucesso)}
 .exam-card h3{color:var(--cor-texto-principal);margin-bottom:10px;font-size:1.2rem;font-weight:600}
 .exam-card p{color:var(--cor-texto-secundario);font-size:.9rem}
 .exam-actions{position:absolute;top:15px;right:15px;display:flex;gap:8px}
@@ -55,51 +90,51 @@ body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(
 .finding-controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:10px}
 .toggle-button{padding:8px 16px;border:1px solid var(--cor-borda);background-color:var(--cor-superficie);border-radius:8px;cursor:pointer;transition:all .2s ease;font-size:.9rem;font-weight:500}
 .toggle-button:hover{border-color:var(--cor-texto-secundario);background-color:#f1f3f5}
-.toggle-button.active{background-color:var(--cor-sucesso);border-color:var(--cor-sucesso);color:#fff;font-weight:600}
+.toggle-button.active{background-color:var(--cor-sucesso);border-color:var(--cor-sucesso);color:#000;font-weight:600}
 .button-group{display:flex;gap:15px;margin-top:30px;justify-content:center}
-.btn{padding:12px 30px;border:none;border-radius:8px;font-size:1rem;cursor:pointer;transition:all .2s ease;font-weight:600;letter-spacing:.5px}
+.btn{padding:12px 30px;border:none;border-radius:8px;font-size:1rem;cursor:pointer;transition:all .2s ease;font-weight:600;letter-spacing:.5px; color: #fff;}
 .btn:hover{transform:translateY(-2px);box-shadow:var(--sombra-suave)}
 .btn-primary{background-color:var(--cor-primaria);color:#fff}
 .btn-primary:hover{background-color:var(--cor-primaria-hover)}
 .btn-secondary{background-color:var(--cor-texto-secundario);color:#fff}
-.btn-success{background-color:var(--cor-sucesso);color:#fff}
+.btn-success{background-color:var(--cor-sucesso);color:#000}
 .btn-danger{background-color:var(--cor-perigo);color:#fff}
 .btn-small{padding:6px 12px;font-size:.8rem}
-.result-area{background-color:#f8f9fa;border:1px solid var(--cor-borda);border-radius:8px;padding:20px;margin:20px 0;font-family:'Courier New',monospace;line-height:1.8;white-space:pre-wrap;max-height:400px;overflow-y:auto}
-.preview-panel{position:fixed;right:20px;top:120px;width:300px;background:var(--cor-superficie);border:1px solid var(--cor-borda);border-radius:12px;padding:20px;box-shadow:var(--sombra-suave);max-height:500px;overflow-y:auto}
+.result-area{background-color:var(--cor-fundo);border:1px solid var(--cor-borda);border-radius:8px;padding:20px;margin:20px 0;font-family:'Courier New',monospace;line-height:1.8;white-space:pre-wrap;max-height:400px;overflow-y:auto}
+.preview-panel{position:fixed;right:20px;top:120px;width:300px;background:var(--cor-superficie);border:1px solid var(--cor-borda);border-radius:12px;padding:20px;box-shadow:var(--sombra-suave);max-height:calc(100vh - 140px);overflow-y:auto}
 .form-group{margin-bottom:15px}
 .form-group label{display:block;margin-bottom:5px;font-weight:500}
-.form-group input,.form-group textarea, .form-group select {width:100%;padding:10px;border:1px solid var(--cor-borda);border-radius:8px;font-size:1rem;transition:all .2s ease}
+.form-group input,.form-group textarea, .form-group select {width:100%;padding:10px;border:1px solid var(--cor-borda);border-radius:8px;font-size:1rem;transition:all .2s ease; background-color: var(--cor-fundo); color: var(--cor-texto-principal);}
 .form-group input:focus,.form-group textarea:focus, .form-group select:focus {border-color:var(--cor-primaria);box-shadow:0 0 0 3px rgba(0,123,255,.25);outline:none}
 .hidden{display:none}
-.modal{display:none;position:fixed;z-index:1000;left:0;top:0;width:100%;height:100%;background-color:rgba(0,0,0,.5);animation:fadeIn .3s ease}
-.modal-content{background-color:var(--cor-superficie);margin:5% auto;padding:30px;border-radius:12px;width:80%;max-width:600px;max-height:80vh;overflow-y:auto;animation:slideIn .3s ease}
+.modal{display:none;position:fixed;z-index:1000;left:0;top:0;width:100%;height:100%;background-color:rgba(0,0,0,.7);animation:fadeIn .3s ease}
+.modal-content{background-color:var(--cor-superficie);margin:5% auto;padding:30px;border-radius:12px;width:80%;max-width:600px;max-height:80vh;overflow-y:auto;animation:slideIn .3s ease; border: 1px solid var(--cor-borda);}
 @keyframes fadeIn{from{opacity:0}to{opacity:1}}
 @keyframes slideIn{from{transform:translateY(-20px);opacity:0}to{transform:translateY(0);opacity:1}}
-.modal-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:20px}
-.close{font-size:28px;font-weight:700;cursor:pointer;color:#aaa}
+.modal-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:20px; border-bottom: 1px solid var(--cor-borda); padding-bottom: 15px;}
+.close{font-size:28px;font-weight:700;cursor:pointer;color:var(--cor-texto-secundario)}
 .category-actions{display:flex;gap:5px;align-items:center}
 .finding-detail-container{display:none;margin-top:10px;width:45%;margin-left:auto}
 .finding-item.has-selection .finding-detail-container{display:block}
-.finding-detail-input{width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;font-size:.9rem}
-.finding-actions-container{display:none;flex-wrap:wrap;gap:10px;margin-top:10px;padding-top:10px;border-top:1px solid #f0f0f0;justify-content:flex-end}
+.finding-detail-input{width:100%;padding:8px;border:1px solid var(--cor-borda);border-radius:4px;font-size:.9rem}
+.finding-actions-container{display:none;flex-wrap:wrap;gap:10px;margin-top:10px;padding-top:10px;border-top:1px solid var(--cor-borda);justify-content:flex-end}
 .finding-item.has-selection .finding-actions-container{display:flex}
-.action-btn{padding:8px 12px;border-radius:6px;border:1px solid var(--cor-borda);background-color:#f8f8f8;cursor:pointer;font-size:.85rem;font-weight:500;transition:all .2s ease}
+.action-btn{padding:8px 12px;border-radius:6px;border:1px solid var(--cor-borda);background-color:var(--cor-superficie);cursor:pointer;font-size:.85rem;font-weight:500;transition:all .2s ease; color: var(--cor-texto-principal)}
 .action-btn:hover{border-color:var(--cor-texto-secundario);transform:translateY(-1px)}
-.action-btn.info-btn{background-color:#eaf5ff;border-color:var(--cor-primaria);color:var(--cor-primaria)}
+.action-btn.info-btn{background-color:rgba(187, 134, 252, 0.1);border-color:var(--cor-primaria);color:var(--cor-primaria)}
 .preview-panel {
   position: fixed;
   right: var(--panel-offset-right);
   top: 120px;
   width: var(--panel-width);
-  background: #ffffff;
-  border: 1px solid #dee2e6;
+  background: var(--cor-superficie);
+  border: 1px solid var(--cor-borda);
   border-radius: 12px;
   padding: 20px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  max-height: 500px;
+  box-shadow: var(--sombra-suave);
+  max-height: calc(100vh - 140px);
   overflow-y: auto;
-  transition: transform 0.35s ease-in-out;
+  transition: transform 0.35s ease-in-out, background-color 0.3s, border-color 0.3s;
   transform: translateX(0);
   z-index: 100;
 }
@@ -113,21 +148,21 @@ body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(
   width: 44px;
   height: 44px;
   border-radius: 8px;
-  background-color: #ffffff;
+  background-color: var(--cor-superficie);
   color: var(--cor-primaria);
   border: 1px solid var(--cor-borda);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  box-shadow: var(--sombra-suave);
   z-index: 300;
-  transition: right 0.35s ease, background-color .15s ease, transform .15s ease;
+  transition: right 0.35s ease, background-color .15s ease, transform .15s ease, border-color 0.3s;
 }
 .toggle-preview-btn.collapse-edge {
   right: var(--panel-offset-right);
 }
-.toggle-preview-btn:hover { background-color: #f8f9fa; }
+.toggle-preview-btn:hover { background-color: var(--cor-fundo); }
 .answer-wrapper {
     display: flex;
     align-items: center;

--- a/escalas/index.html
+++ b/escalas/index.html
@@ -12,11 +12,14 @@
             <h1>Prontuário Fácil - Escalas Médicas</h1>
             <p>Aplique escalas com cálculo automático de pontuação.</p>
            <div class="header-actions">
-                <button class="btn btn-primary btn-small" onclick="location.href='../index.html'">Voltar</button>
-                <div style="display: flex; gap: 8px;">
+                <div class="left-actions">
+                    <button class="btn btn-primary btn-small" onclick="location.href='../index.html'">Voltar</button>
+                </div>
+                <div style="display: flex; gap: 8px; align-items: center;">
                     <button class="btn btn-secondary btn-small" onclick="exportData()">Exportar</button>
                     <label class="btn btn-secondary btn-small" style="display:inline-flex;align-items:center;cursor:pointer">Importar<input type="file" accept="application/json" onchange="handleImport(this.files[0])" style="display:none"></label>
                     <button class="btn btn-danger btn-small" onclick="masterReset()">Reset Total</button>
+                    <button id="theme-toggle" class="theme-toggle-btn">?</button>
                 </div>
             </div>
         </div>
@@ -62,12 +65,12 @@
         <button class="btn btn-secondary" onclick="backToSelection()">Voltar</button>
         <button class="btn btn-primary" onclick="generateReport()">Gerar Resultado</button>
     </div>
-  
-            <div id="previewPanel" class="preview-panel">
-                <h3>Pré-visualização do Resultado</h3>
-                <div id="previewContent">Selecione as respostas...</div>
-            </div>
-        </div>
+    <button id="togglePreviewBtn" class="toggle-preview-btn" aria-label="Alternar pré-visualização">»</button>
+    <div id="previewPanel" class="preview-panel">
+        <h3>Pré-visualização do Resultado</h3>
+        <div id="previewContent">Selecione as respostas...</div>
+    </div>
+</div>
 
         <div id="screen3" class="screen">
             <h2>Resultado da Escala</h2>

--- a/index.html
+++ b/index.html
@@ -12,12 +12,15 @@
             <h1>Prontuário Fácil</h1>
             <p>Versão 0.0.8</p>
            <div class="header-actions">
-                <button class="btn btn-primary btn-small" onclick="location.href='escalas/index.html'">Acessar Escalas</button>
-                <button class="btn btn-primary btn-small" onclick="openHelpModal()">Ajuda</button>
-                <div style="display: flex; gap: 8px;">
+                <div class="left-actions">
+                    <button class="btn btn-primary btn-small" onclick="location.href='escalas/index.html'">Acessar Escalas</button>
+                    <button class="btn btn-primary btn-small" onclick="openHelpModal()">Ajuda</button>
+                </div>
+                <div style="display: flex; gap: 8px; align-items: center;">
                     <button class="btn btn-secondary btn-small" onclick="exportData()">Exportar</button>
                     <label class="btn btn-secondary btn-small" style="display:inline-flex;align-items:center;cursor:pointer">Importar<input type="file" accept="application/json" onchange="handleImport(this.files[0])" style="display:none"></label>
                     <button class="btn btn-danger btn-small" onclick="masterReset()">Reset Total</button>
+                    <button id="theme-toggle" class="theme-toggle-btn">?</button>
                 </div>
             </div>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadCustomData();
     renderExamSelection();
     loadSessionState();
+    setupTheme();
     const panel = document.getElementById('previewPanel');
     const btn = document.getElementById('togglePreviewBtn');
     if (panel && btn) {

--- a/js/scales.js
+++ b/js/scales.js
@@ -8,6 +8,18 @@ document.addEventListener('DOMContentLoaded', function() {
     loadCustomData();
     renderScaleSelection();
     loadSessionState();
+    setupTheme();
+
+    const panel = document.getElementById('previewPanel');
+    const btn = document.getElementById('togglePreviewBtn');
+    if (panel && btn) {
+        panel.classList.remove('collapsed');
+        btn.textContent = '»';
+        btn.title = 'Ocultar pré-visualização';
+        btn.addEventListener('click', togglePreviewPanel);
+        positionPreviewToggle();
+        window.addEventListener('resize', positionPreviewToggle);
+    }
 });
 
 // ======== NAVEGAÇÃO E LÓGICA DE TELAS ========
@@ -273,6 +285,47 @@ function selectAnswer(questionId, answerId) {
         answersState[questionId] = { answerId: answerId };
     }
     renderQuestions();
+}
+
+function positionPreviewToggle() {
+  const panel = document.getElementById('previewPanel');
+  const btn = document.getElementById('togglePreviewBtn');
+  if (!panel || !btn) return;
+
+  const rootStyles = getComputedStyle(document.documentElement);
+  const panelWidth = parseInt(rootStyles.getPropertyValue('--panel-width')) || 300;
+  const panelOffset = parseInt(rootStyles.getPropertyValue('--panel-offset-right')) || 20;
+  const screen2IsActive = document.getElementById('screen2').classList.contains('active');
+
+  if (!screen2IsActive) {
+    btn.classList.add('collapse-edge');
+    btn.style.right = `${panelOffset}px`;
+    return;
+  }
+
+  if (panel.classList.contains('collapsed')) {
+    btn.classList.add('collapse-edge');
+    btn.style.right = `${panelOffset}px`;
+  } else {
+    btn.classList.remove('collapse-edge');
+    btn.style.right = `${panelOffset + panelWidth + 8}px`;
+  }
+}
+
+function togglePreviewPanel() {
+  const panel = document.getElementById('previewPanel');
+  const btn = document.getElementById('togglePreviewBtn');
+
+  panel.classList.toggle('collapsed');
+
+  if (panel.classList.contains('collapsed')) {
+    btn.textContent = '«';
+    btn.title = 'Mostrar pré-visualização';
+  } else {
+    btn.textContent = '»';
+    btn.title = 'Ocultar pré-visualização';
+  }
+  positionPreviewToggle();
 }
 
 // ======== LÓGICA DE PONTUAÇÃO E INTERPRETAÇÃO ========

--- a/js/utils.js
+++ b/js/utils.js
@@ -2,6 +2,26 @@
 function showScreen(screenId) {
     document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
     document.getElementById(screenId).classList.add('active');
+    if(typeof positionPreviewToggle === 'function') {
+        positionPreviewToggle();
+    }
+}
+
+function setupTheme() {
+    const toggleButton = document.getElementById('theme-toggle');
+    const currentTheme = localStorage.getItem('theme') || 'light';
+
+    document.documentElement.setAttribute('data-theme', currentTheme);
+
+    if (toggleButton) {
+        toggleButton.textContent = currentTheme === 'dark' ? '🌙' : '☀️';
+        toggleButton.addEventListener('click', () => {
+            let newTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', newTheme);
+            localStorage.setItem('theme', newTheme);
+            toggleButton.textContent = newTheme === 'dark' ? '🌙' : '☀️';
+        });
+    }
 }
 
 // ======== PERSISTÊNCIA ========


### PR DESCRIPTION
This commit introduces a dark mode to the application, enhancing user experience by providing an alternative color scheme. The theme is toggled via a button in the header, and the choice is persisted across sessions using localStorage.

Key changes include:
- Addition of CSS variables for a dark theme in `css/style.css`.
- A new `setupTheme` function in `js/utils.js` to manage theme state.
- Theme toggle buttons added to `index.html` and `escalas/index.html`.

Additionally, this commit addresses several UI/UX improvements based on user feedback:
- The "Ajuda" button is now grouped with the "Acessar Escalas" button for better navigation consistency.
- The preview panel on the scales page is now collapsible, mirroring the functionality of the main page's panel. This was achieved by adding the necessary HTML button and reusing the existing JavaScript logic.
- Minor aesthetic adjustments were made to improve the overall look and feel of the application in both light and dark modes.