### PR TITLE
feat: Implement prescriptions page

### DIFF
--- a/escalas/index.html
+++ b/escalas/index.html
@@ -14,6 +14,7 @@
            <div class="header-actions">
                 <div class="left-actions">
                     <button class="btn btn-primary btn-small" onclick="location.href='../index.html'">Voltar</button>
+                    <button class="btn btn-primary btn-small" onclick="location.href='../prescricoes/index.html'">Acessar Prescrições</button>
                 </div>
                 <div style="display: flex; gap: 8px; align-items: center;">
                     <button class="btn btn-secondary btn-small" onclick="exportData()">Exportar</button>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
            <div class="header-actions">
                 <div class="left-actions">
                     <button class="btn btn-primary btn-small" onclick="location.href='escalas/index.html'">Acessar Escalas</button>
+                    <button class="btn btn-primary btn-small" onclick="location.href='prescricoes/index.html'">Acessar Prescrições</button>
                     <button class="btn btn-primary btn-small" onclick="openHelpModal()">Ajuda</button>
                 </div>
                 <div style="display: flex; gap: 8px; align-items: center;">

--- a/js/prescriptions.js
+++ b/js/prescriptions.js
@@ -1,0 +1,260 @@
+// ======== ESTADO DA APLICAÇÃO ========
+let selectedDiseaseId = null;
+let customPrescriptions = {};
+let editingDiseaseId = null;
+let editingOptionId = null;
+
+// ======== INICIALIZAÇÃO ========
+document.addEventListener('DOMContentLoaded', function() {
+    loadCustomData();
+    renderDiseaseSelection();
+    setupTheme();
+});
+
+// ======== NAVEGAÇÃO E LÓGICA DE TELAS ========
+function showScreen(screenId) {
+    document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+    document.getElementById(screenId).classList.add('active');
+}
+
+function backToSelection() {
+    selectedDiseaseId = null;
+    showScreen('screen1');
+    renderDiseaseSelection();
+}
+
+// ======== LÓGICA DE DADOS (MERGE E BUSCA) ========
+function getMergedPrescriptions() {
+    return { ...prescriptionsData, ...customPrescriptions };
+}
+
+function findDiseaseById(diseaseId) {
+    return getMergedPrescriptions()[diseaseId] || null;
+}
+
+function findOptionById(diseaseId, optionId) {
+    const disease = findDiseaseById(diseaseId);
+    return disease ? (disease.options || []).find(o => o.id === optionId) : null;
+}
+
+// ======== TELA 1: SELEÇÃO DE DOENÇAS ========
+function renderDiseaseSelection() {
+    const grid = document.getElementById('diseaseGrid');
+    grid.innerHTML = '';
+    const allPrescriptions = getMergedPrescriptions();
+    const filterText = (document.getElementById('diseaseSearchInput')?.value || '').toLowerCase();
+
+    const filtered = Object.values(allPrescriptions).filter(p =>
+        p && p.name && p.name.toLowerCase().includes(filterText)
+    );
+
+    filtered.forEach(disease => {
+        const card = document.createElement('div');
+        card.className = 'exam-card';
+        const isCustom = disease.id.startsWith('custom_');
+
+        card.innerHTML = `<h3>${disease.name}</h3>
+        <div class="exam-actions">
+            ${isCustom ? `<button class="icon-btn edit" onclick="openEditDiseaseForm('${disease.id}', event)" title="Editar Nome">✎</button>
+                         <button class="icon-btn delete" onclick="deleteDisease('${disease.id}', event)" title="Deletar Doença">×</button>` : ''}
+        </div>`;
+
+        card.onclick = () => {
+            selectedDiseaseId = disease.id;
+            renderPrescriptionOptions();
+            showScreen('screen2');
+        };
+        grid.appendChild(card);
+    });
+}
+
+function toggleAddDiseaseForm() {
+    const form = document.getElementById('addDiseaseForm');
+    form.classList.toggle('hidden');
+    if (!form.classList.contains('hidden')) {
+        document.getElementById('diseaseFormTitle').textContent = 'Adicionar Nova Doença';
+        document.getElementById('newDiseaseName').value = '';
+        const saveBtn = document.getElementById('saveDiseaseBtn');
+        saveBtn.textContent = 'Adicionar';
+        saveBtn.onclick = addNewDisease;
+        editingDiseaseId = null;
+    }
+}
+
+function addNewDisease() {
+    const name = document.getElementById('newDiseaseName').value.trim();
+    if (!name) return alert("O nome da doença é obrigatório.");
+
+    const newId = 'custom_' + Date.now();
+    customPrescriptions[newId] = {
+        id: newId,
+        name: name,
+        options: []
+    };
+    saveCustomData();
+    toggleAddDiseaseForm();
+    renderDiseaseSelection();
+}
+
+function openEditDiseaseForm(diseaseId, event) {
+    event.stopPropagation();
+    const disease = customPrescriptions[diseaseId];
+    if (!disease) return;
+
+    editingDiseaseId = diseaseId;
+    document.getElementById('newDiseaseName').value = disease.name;
+    document.getElementById('diseaseFormTitle').textContent = 'Editar Doença';
+    const saveBtn = document.getElementById('saveDiseaseBtn');
+    saveBtn.textContent = 'Salvar Alterações';
+    saveBtn.onclick = saveDiseaseChanges;
+
+    const form = document.getElementById('addDiseaseForm');
+    form.classList.remove('hidden');
+}
+
+function saveDiseaseChanges() {
+    if (!editingDiseaseId) return;
+    const name = document.getElementById('newDiseaseName').value.trim();
+    if (!name) return alert("O nome da doença é obrigatório.");
+
+    customPrescriptions[editingDiseaseId].name = name;
+    saveCustomData();
+    toggleAddDiseaseForm();
+    renderDiseaseSelection();
+}
+
+function deleteDisease(diseaseId, event) {
+    event.stopPropagation();
+    if (confirm('Tem certeza que deseja deletar esta doença e todas as suas opções?')) {
+        delete customPrescriptions[diseaseId];
+        saveCustomData();
+        renderDiseaseSelection();
+    }
+}
+
+// ======== TELA 2: OPÇÕES DE PRESCRIÇÃO ========
+function renderPrescriptionOptions() {
+    const disease = findDiseaseById(selectedDiseaseId);
+    if (!disease) {
+        backToSelection();
+        return;
+    }
+
+    document.getElementById('prescriptionTitle').textContent = `Prescrições para: ${disease.name}`;
+    const container = document.getElementById('optionsContainer');
+    container.innerHTML = '';
+
+    (disease.options || []).forEach(option => {
+        const isCustom = selectedDiseaseId.startsWith('custom_');
+        const item = document.createElement('div');
+        item.className = 'prescription-item';
+        item.innerHTML = `
+            <div class="prescription-header">
+                <strong>${option.name}</strong>
+                <div class="prescription-actions">
+                    <button class="btn btn-success btn-small" onclick="copyToClipboard('${option.id}')">Copiar</button>
+                    ${isCustom ? `<button class="btn btn-secondary btn-small" onclick="openEditOptionModal('${option.id}')">Editar</button>
+                                 <button class="btn btn-danger btn-small" onclick="deleteOption('${option.id}')">Deletar</button>` : ''}
+                </div>
+            </div>
+            <div class="prescription-text">${option.text.replace(/\n/g, '<br>')}</div>
+        `;
+        container.appendChild(item);
+    });
+}
+
+function copyToClipboard(optionId) {
+    const option = findOptionById(selectedDiseaseId, optionId);
+    if (option) {
+        navigator.clipboard.writeText(option.text).then(() => alert('Prescrição copiada para a área de transferência!'));
+    }
+}
+
+// ======== MODAL DE OPÇÕES (ADICIONAR/EDITAR) ========
+function toggleAddOptionForm() {
+    editingOptionId = null;
+    document.getElementById('optionModalTitle').textContent = 'Adicionar Nova Opção';
+    document.getElementById('optionName').value = '';
+    document.getElementById('optionText').value = '';
+    document.getElementById('saveOptionBtn').onclick = addNewOption;
+    document.getElementById('optionModal').style.display = 'block';
+}
+
+function openEditOptionModal(optionId) {
+    const option = findOptionById(selectedDiseaseId, optionId);
+    if (!option) return;
+
+    editingOptionId = optionId;
+    document.getElementById('optionModalTitle').textContent = 'Editar Opção';
+    document.getElementById('optionName').value = option.name;
+    document.getElementById('optionText').value = option.text;
+    document.getElementById('saveOptionBtn').onclick = saveOptionChanges;
+    document.getElementById('optionModal').style.display = 'block';
+}
+
+function closeOptionModal() {
+    document.getElementById('optionModal').style.display = 'none';
+}
+
+function addNewOption() {
+    const name = document.getElementById('optionName').value.trim();
+    const text = document.getElementById('optionText').value.trim();
+    if (!name || !text) return alert('O nome da opção e o texto da prescrição são obrigatórios.');
+
+    const newOption = {
+        id: `custom_opt_${Date.now()}`,
+        name,
+        text
+    };
+
+    const disease = customPrescriptions[selectedDiseaseId];
+    if (disease) {
+        disease.options.push(newOption);
+        saveCustomData();
+        renderPrescriptionOptions();
+        closeOptionModal();
+    }
+}
+
+function saveOptionChanges() {
+    if (!editingOptionId) return;
+
+    const name = document.getElementById('optionName').value.trim();
+    const text = document.getElementById('optionText').value.trim();
+    if (!name || !text) return alert('O nome da opção e o texto da prescrição são obrigatórios.');
+
+    const disease = customPrescriptions[selectedDiseaseId];
+    if (disease) {
+        const optionIndex = disease.options.findIndex(o => o.id === editingOptionId);
+        if (optionIndex > -1) {
+            disease.options[optionIndex].name = name;
+            disease.options[optionIndex].text = text;
+            saveCustomData();
+            renderPrescriptionOptions();
+            closeOptionModal();
+        }
+    }
+}
+
+function deleteOption(optionId) {
+    if (confirm('Tem certeza que deseja deletar esta opção de prescrição?')) {
+        const disease = customPrescriptions[selectedDiseaseId];
+        if (disease) {
+            disease.options = disease.options.filter(o => o.id !== optionId);
+            saveCustomData();
+            renderPrescriptionOptions();
+        }
+    }
+}
+
+// ======== PERSISTÊNCIA (localStorage) ========
+function saveCustomData() {
+    localStorage.setItem('customPrescriptionsData', JSON.stringify(customPrescriptions));
+}
+
+function loadCustomData() {
+    const data = localStorage.getItem('customPrescriptionsData');
+    if (data) {
+        customPrescriptions = JSON.parse(data);
+    }
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -38,6 +38,9 @@ function saveCustomData() {
     if (typeof customScales !== 'undefined') {
         localStorage.setItem('customScales', JSON.stringify(customScales));
     }
+    if (typeof customPrescriptions !== 'undefined') {
+        localStorage.setItem('customPrescriptionsData', JSON.stringify(customPrescriptions));
+    }
 }
 
 function loadCustomData() {
@@ -56,6 +59,10 @@ function loadCustomData() {
     if (typeof customScales !== 'undefined') {
         const cs = localStorage.getItem('customScales');
         if (cs) customScales = JSON.parse(cs);
+    }
+    if (typeof customPrescriptions !== 'undefined') {
+        const cp = localStorage.getItem('customPrescriptionsData');
+        if (cp) customPrescriptions = JSON.parse(cp);
     }
 }
 
@@ -113,6 +120,9 @@ function exportData() {
     } else if (typeof customScales !== 'undefined') {
         dataToExport = { customScales };
         fileName = `escalas_config_${new Date().toISOString().slice(0,10)}.json`;
+    } else if (typeof customPrescriptions !== 'undefined') {
+        dataToExport = { customPrescriptions };
+        fileName = `prescricoes_config_${new Date().toISOString().slice(0,10)}.json`;
     }
 
     const blob = new Blob([JSON.stringify(dataToExport, null, 2)], { type: "application/json" });
@@ -139,6 +149,11 @@ function handleImport(file) {
                 saveCustomData();
                 renderScaleSelection();
                 alert('Escalas importadas com sucesso!');
+            } else if (typeof customPrescriptions !== 'undefined' && d.customPrescriptions) {
+                customPrescriptions = { ...customPrescriptions, ...d.customPrescriptions };
+                saveCustomData();
+                renderDiseaseSelection();
+                alert('Prescrições importadas com sucesso!');
             } else {
                 alert('Arquivo inválido.');
             }

--- a/prescricoes/index.html
+++ b/prescricoes/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prontuário Fácil - Prescrições Médicas</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div class="container">
+        <!-- Header -->
+        <div class="header">
+            <h1>Prontuário Fácil - Prescrições</h1>
+            <p>Crie e gerencie seus modelos de prescrição.</p>
+            <div class="header-actions">
+                <div class="left-actions">
+                    <button class="btn btn-primary btn-small" onclick="location.href='../index.html'">Voltar</button>
+                </div>
+                <div style="display: flex; gap: 8px; align-items: center;">
+                    <button class="btn btn-secondary btn-small" onclick="exportData()">Exportar</button>
+                    <label class="btn btn-secondary btn-small">Importar<input type="file" accept="application/json" onchange="handleImport(this.files[0])" style="display:none"></label>
+                    <button class="btn btn-danger btn-small" onclick="masterReset()">Reset Total</button>
+                    <button id="theme-toggle" class="theme-toggle-btn">?</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Screen 1: Disease Selection -->
+        <div id="screen1" class="screen active">
+            <h2>Selecione a Doença</h2>
+            <div class="form-group" style="margin-bottom:20px">
+                <input type="text" id="diseaseSearchInput" onkeyup="renderDiseaseSelection()" placeholder="Buscar por nome...">
+            </div>
+            <div class="exam-grid" id="diseaseGrid"></div>
+            <div class="button-group">
+                <button class="btn btn-secondary" onclick="toggleAddDiseaseForm()">Adicionar Nova Doença</button>
+            </div>
+            <!-- Add Disease Form -->
+            <div id="addDiseaseForm" class="add-exam-form hidden">
+                <h3 id="diseaseFormTitle">Adicionar Nova Doença</h3>
+                <div class="form-group">
+                    <label for="newDiseaseName">Nome da Doença:</label>
+                    <input type="text" id="newDiseaseName">
+                </div>
+                <div class="button-group">
+                    <button id="saveDiseaseBtn" class="btn btn-success" onclick="addNewDisease()">Adicionar</button>
+                    <button class="btn btn-secondary" onclick="toggleAddDiseaseForm()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Screen 2: Prescription Options -->
+        <div id="screen2" class="screen">
+            <h2 id="prescriptionTitle">Prescrições para...</h2>
+            <div id="optionsContainer"></div>
+            <div class="button-group">
+                <button class="btn btn-secondary" onclick="backToSelection()">Voltar</button>
+                <button class="btn btn-primary" onclick="toggleAddOptionForm()">Adicionar Nova Opção</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Add/Edit Option Modal -->
+    <div id="optionModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="optionModalTitle">Adicionar/Editar Opção</h3>
+                <span class="close" onclick="closeOptionModal()">&times;</span>
+            </div>
+            <div class="form-group">
+                <label for="optionName">Nome da Opção (ex: Tratamento Oral):</label>
+                <input type="text" id="optionName">
+            </div>
+            <div class="form-group">
+                <label for="optionText">Texto da Prescrição:</label>
+                <textarea id="optionText" rows="10"></textarea>
+            </div>
+            <div class="button-group">
+                <button id="saveOptionBtn" class="btn btn-success">Salvar</button>
+                <button class="btn btn-secondary" onclick="closeOptionModal()">Cancelar</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="prescricoesNativas.js"></script>
+    <script src="../js/utils.js"></script>
+    <script src="../js/prescriptions.js"></script>
+</body>
+</html>

--- a/prescricoes/prescricoesNativas.js
+++ b/prescricoes/prescricoesNativas.js
@@ -1,0 +1,34 @@
+const prescriptionsData = {
+    "disease_1": {
+        "id": "disease_1",
+        "name": "Anemia Ferropriva",
+        "options": [
+            {
+                "id": "option_1_1",
+                "name": "Tratamento Oral",
+                "text": "Sulfato Ferroso 300mg, 1 comprimido, via oral, 2 vezes ao dia, por 3 meses."
+            },
+            {
+                "id": "option_1_2",
+                "name": "Tratamento Endovenoso",
+                "text": "Ferinject 500mg, 1 ampola, via endovenosa, diluído em 250ml de soro fisiológico, correr em 1 hora."
+            }
+        ]
+    },
+    "disease_2": {
+        "id": "disease_2",
+        "name": "Hipertensão Arterial Sistêmica",
+        "options": [
+            {
+                "id": "option_2_1",
+                "name": "Tratamento Inicial",
+                "text": "Losartana 50mg, 1 comprimido, via oral, 1 vez ao dia."
+            },
+            {
+                "id": "option_2_2",
+                "name": "Tratamento Associado",
+                "text": "Anlodipino 5mg, 1 comprimido, via oral, 1 vez ao dia."
+            }
+        ]
+    }
+};


### PR DESCRIPTION
This commit introduces a new 'prescrições' (prescriptions) page to the application.

The new page allows users to create and manage a list of diseases and, for each disease, a set of prescription options. This provides a way for users to store and quickly access their custom prescription templates.

Key features of this implementation include:
- A new `/prescricoes` directory containing the page's HTML and native data.
- A dedicated JavaScript file, `js/prescriptions.js`, for the page's logic, including CRUD operations for diseases and prescription options.
- Integration with the existing `localStorage`-based system for custom data persistence.
- Navigation buttons added to the main page and the 'escalas' page for easy access.
- The import/export functionality has been extended to support the new prescriptions data.