### PR TITLE
Fix(export): Repair non-functional export button

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@ let selectedExams = [];
 let findingsState = {};
 let customExams = {};
 let customAdditions = {};
+let likelihoodData = {};
 
 // ======== INICIALIZAÇÃO ========
 document.addEventListener('DOMContentLoaded', function() {

--- a/js/prescriptions.js
+++ b/js/prescriptions.js
@@ -248,13 +248,4 @@ function deleteOption(optionId) {
 }
 
 // ======== PERSISTÊNCIA (localStorage) ========
-function saveCustomData() {
-    localStorage.setItem('customPrescriptionsData', JSON.stringify(customPrescriptions));
-}
-
-function loadCustomData() {
-    const data = localStorage.getItem('customPrescriptionsData');
-    if (data) {
-        customPrescriptions = JSON.parse(data);
-    }
-}
+// As funções saveCustomData e loadCustomData foram centralizadas em js/utils.js

--- a/js/utils.js
+++ b/js/utils.js
@@ -39,7 +39,7 @@ function saveCustomData() {
         localStorage.setItem('customScales', JSON.stringify(customScales));
     }
     if (typeof customPrescriptions !== 'undefined') {
-        localStorage.setItem('customPrescriptionsData', JSON.stringify(customPrescriptions));
+        localStorage.setItem('customPrescriptions', JSON.stringify(customPrescriptions));
     }
 }
 
@@ -61,7 +61,7 @@ function loadCustomData() {
         if (cs) customScales = JSON.parse(cs);
     }
     if (typeof customPrescriptions !== 'undefined') {
-        const cp = localStorage.getItem('customPrescriptionsData');
+        const cp = localStorage.getItem('customPrescriptions');
         if (cp) customPrescriptions = JSON.parse(cp);
     }
 }


### PR DESCRIPTION
This commit fixes an issue where the 'Exportar' button was not working on the 'Laudos' and 'Prescrições' pages.

The root causes were:
1. A `ReferenceError` on the 'Laudos' page due to the `likelihoodData` variable not being declared before being used in the export function. This was fixed by initializing the variable in `js/main.js`.
2. An inconsistent `localStorage` key being used for custom prescription data. This was fixed by correcting the key in `js/utils.js` and removing the redundant, incorrect data handling functions from `js/prescriptions.js` to rely on the centralized, corrected versions.