### PR TITLE
Fix button styles and add responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,6 +109,13 @@ body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(
 .btn-danger{background-color:var(--cor-perigo);color:#fff}
 .btn-small{padding:6px 12px;font-size:.8rem}
 
+label.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+}
+
 .result-area{background-color:var(--cor-fundo);border:1px solid var(--cor-borda);border-radius:8px;padding:20px;margin:20px 0;font-family:'Courier New',monospace;line-height:1.8;white-space:pre-wrap;max-height:400px;overflow-y:auto}
 .preview-panel{position:fixed;right:20px;top:120px;width:300px;background:var(--cor-superficie);border:1px solid var(--cor-borda);border-radius:12px;padding:20px;box-shadow:var(--sombra-suave);max-height:calc(100vh - 140px);overflow-y:auto}
 .form-group{margin-bottom:15px}
@@ -221,4 +228,27 @@ body{font-family:'Inter',sans-serif;background-color:var(--cor-fundo);color:var(
     color: var(--cor-texto-principal);
     margin-top: 0;
     margin-bottom: 10px;
+}
+
+@media (max-width: 768px) {
+    .header-actions {
+        position: static;
+        flex-direction: column;
+        gap: 12px;
+        margin-top: 20px;
+    }
+    .header {
+        padding-bottom: 20px;
+    }
+    .header-actions .left-actions,
+    .header-actions > div:nth-child(2) {
+        flex-direction: column;
+        width: 100%;
+        gap: 12px;
+    }
+    .header-actions .btn, .header-actions .btn-small, .header-actions label.btn {
+        width: 100%;
+        padding: 12px;
+        font-size: 1rem;
+    }
 }


### PR DESCRIPTION
This commit addresses two issues:
1.  The 'Importar' button was larger than other buttons because it was a `label` element. A specific CSS rule has been added to `label.btn` to ensure it has the same size and alignment as the other buttons.
2.  The header buttons were not responsive on mobile devices. A media query has been added to stack the buttons and adjust their size on smaller screens, improving the user experience on mobile.